### PR TITLE
Bad pattern: using lifecycle effect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/litmon/app/example/nfc_scanner/NfcScanEffect.kt
+++ b/app/src/main/java/com/litmon/app/example/nfc_scanner/NfcScanEffect.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.compose.LifecycleResumeEffect
 
 @Composable
 fun TagScanEffect(
@@ -43,10 +44,10 @@ fun <T : Any> NfcScanEffect(
     onScanned: (T) -> Unit,
 ) {
     val rememberedScanner = remember { scanner() }
-    DisposableEffect(rememberedScanner) {
+    LifecycleResumeEffect(rememberedScanner) {
         rememberedScanner.start(onScanned)
 
-        onDispose {
+        onPauseOrDispose {
             rememberedScanner.stop()
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
LifecycleResumeEffect を使ったパターン
これだと onStop 時に scanner.stop() が実行されてしまい、 onNewIntent を受け取る前に removeOnNewIntentListener を呼び出す形になってしまうため読み取りできなくなってしまう。

参考事例として残しておく。